### PR TITLE
Implemented the endpoint to fetch all comments for a specific article

### DIFF
--- a/__tests__/comments.test.js
+++ b/__tests__/comments.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const app = require('../app');
+const db = require('../db/connection');
+const seed = require('../db/seeds/seed');
+const testData = require('../db/data/test-data/index');
+
+beforeEach(() => seed(testData));
+afterAll(() => db.end());
+
+describe('GET /api/articles/:article_id/comments', () => {
+    let validArticleId;
+
+
+    beforeEach(() => {
+        return db.query('SELECT article_id FROM articles LIMIT 1;').then(({ rows }) => {
+            validArticleId = rows[0].article_id;
+        });
+    });
+
+    test('200: responds with an array of comment objects for the given article_id, sorted by date in descending order', () => {
+        return request(app)
+        .get(`/api/articles/${validArticleId}/comments`)
+        .expect(200)
+        .then((response) => {
+            const comments = response.body.comments;
+            expect(comments).toBeInstanceOf(Array);
+            expect(comments).toHaveLength(testData.commentData.filter(comment => comment.article_id === 1).length);
+            expect(comments).toBeSortedBy('created_at', { descending: true });
+
+            comments.forEach((comment) => {
+                expect(comment).toEqual(
+                    expect.objectContaining({
+                        comment_id: expect.any(Number),
+                        votes: expect.any(Number),
+                        created_at: expect.any(String),
+                        author: expect.any(String),
+                        body: expect.any(String),
+                        article_id: expect.any(Number),
+                    })
+                )
+            })
+        })
+    })
+
+
+    test('404: responds with an error message when article is not found', () => {
+        return request(app)
+        .get('/api/articles/99999/comments')
+        .expect(404)
+        .then((response) => {
+            expect(response.body.msg).toBe('Article not found');
+        });
+    });
+
+
+    test('400: responds with an error message when article_id is invalid', () => {
+        return request(app)
+        .get('/api/articles/not-a-number/comments')
+        .expect(400)
+        .then((response) => {
+            expect(response.body.msg).toBe('Bad request');
+        });
+    });
+})

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const app = express();
 const { getApi } = require('./controllers/api.controllers')
 const { getTopics } = require('./controllers/topics.controllers');
 const { getArticleById, getArticles } = require('./controllers/articles.controllers');
+const { getCommentsByArticleId } = require('./controllers/comments.controllers');
 const { handleCustomErrors, handlePsqlErrors, handleServerErrors } = require('./errors');
 
 app.use(express.json());
@@ -11,7 +12,7 @@ app.get('/api', getApi)
 app.get('/api/topics', getTopics);
 app.get('/api/articles', getArticles);
 app.get('/api/articles/:article_id', getArticleById);
-
+app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
 
 app.all('/*', (req, res) => {
     res.status(404).send({ msg: 'Route not found' });

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,0 +1,14 @@
+const { selectCommentsByArticleId } = require('../model/comments.models');
+
+exports.getCommentsByArticleId = (req, res, next) => {
+    const { article_id } = req.params;
+
+    selectCommentsByArticleId(article_id)
+    .then((comments) => {
+        if (comments.length === 0) {
+            return res.status(404).send({ msg: 'Article not found' });
+        }
+        res.status(200).send({ comments });
+    })
+    .catch(next);
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -42,5 +42,22 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+
+  "GET /api/articles/:article_id/comments": {
+    "description": "serves an array of comments for the given article_id",
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 1,
+          "votes": 14,
+          "created_at": "2020-11-03T21:00:00.000Z",
+          "author": "butter_bridge",
+          "body": "This is a comment",
+          "article_id": 1
+        }
+      ]
+    }
   }
+
 }

--- a/model/comments.models.js
+++ b/model/comments.models.js
@@ -1,0 +1,15 @@
+const db = require('../db/connection');
+
+exports.selectCommentsByArticleId = (article_id) => {
+    return db
+    .query(
+      `SELECT comment_id, votes, created_at, author, body, article_id
+       FROM comments
+       WHERE article_id = $1
+       ORDER BY created_at DESC;`,
+       [article_id]
+    )
+    .then((result) => {
+        return result.rows;
+    });
+};


### PR DESCRIPTION
- Implemented the endpoint to fetch all comments for a specific article.
- Each comment includes comment_id, votes, created_at, author, body, and article_id.
- Comments are served with the most recent comments first (sorted by created_at in descending order).
- Added error handling for non-existent and invalid article_id.
- Updated the /api endpoint documentation to include the new endpoint.